### PR TITLE
Update MET-003 for negative evaluation

### DIFF
--- a/rules/MET-003.md
+++ b/rules/MET-003.md
@@ -1,12 +1,12 @@
 **Rule ID:** MET-003
 
-**Description:** A Metric name is consistently associated with the same metric unit.
+**Description:** A Metric name is not consistently associated with the same metric unit.
 
 **Rationale:** Metric units are fundamental in understanding what a metric means, and how to analyze it. Metric units are specified in the OpenTelemetry SDKs when their instruments are created, and it is possible for different applications to use the same metric name with different metric units, creating chaos during analysis.
 
 **Target:** Metric
 
-**Criteria:** In any given timeframe, all time series associated with a given metric name have the same unit.
+**Criteria:** In the past 14 days, not all time series associated with a given metric name have the same unit.
 
 **Severity:** Very Important
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the rule description and criteria to clarify that metric names are not consistently associated with the same metric unit, specifying a 14-day timeframe for evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->