### PR TITLE
Add sdk rule for supported versions

### DIFF
--- a/rules/SDK-001.md
+++ b/rules/SDK-001.md
@@ -1,0 +1,17 @@
+**Rule ID:** SDK-001
+
+**Description:** Detects if the dependencies (language and runtime) are supported by the SDK.
+
+**Rationale:** Using up-to-date SDKs are recommended, so it can get the proper support from community in case of issues. It also will also mostly likely adhere to the latest Semantic Conventions and features. The version of languages and runtimes should reflect the version selected for the SDK and be within the SDK supported values. 
+
+**Target:** SDK
+
+**Criteria:** The versions of language and runtime found on the instrumentation dependencies for the SDK should be within supported values.
+
+**Examples:**
+
+* JS SDK version v2.0.1 supports Node.JS version 18, 20 and 22 and TypeScript version v5.0.4+, following a support window os 2 years.
+
+**Severity:** Low
+
+**Type:** Positive

--- a/rules/_template.md
+++ b/rules/_template.md
@@ -4,7 +4,7 @@
 
 **Rationale:** \[Explanation of why this rule is important for instrumentation quality. What benefit does adherence provide, or what problem does non-adherence cause? Link to relevant OpenTelemetry specifications (e.g., Semantic Conventions) or established best practices if applicable. Explain the impact on observability, efficiency, or cost.\]
 
-**Target:** \[Specify the primary OTLP element this rule evaluates: Resource | Span | Metric | Log | Profile | Other (Specify)\]
+**Target:** \[Specify the primary OTLP element this rule evaluates: Resource | Span | Metric | Log | Profile | Other (Specify) or the component: SDK | Collector | Other (Specify)\]
 
 **Criteria:** \[The precise, objective conditions under which this rule is triggered when analyzing OTLP data. This description must be unambiguous and algorithmically testable. Provide specific attribute names, expected values or patterns, conditions for presence/absence, thresholds, etc. Use backticks for attribute names or code elements.\]
 


### PR DESCRIPTION
We do get issues on the SKDs where people were using really old versions of things that we no longer support, so I think is valid to also have rules for the implementation itself.
This PR updates the template to reflect a few examples of components and also create a new rule for dependency on SDKs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new rule to detect if language and runtime versions in SDK dependencies are supported, helping ensure compatibility and up-to-date usage.
- **Documentation**
  - Updated rule template to allow rules to target SDKs, Collectors, and other components in addition to OTLP elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->