### PR TITLE
Clarify RES-002.md

### DIFF
--- a/rules/RES-002.md
+++ b/rules/RES-002.md
@@ -1,12 +1,12 @@
 **Rule ID:** RES-002
 
-**Description:** Misused `service.instance.id`
+**Description:** Duplicate `service.instance.id`
 
 **Rationale:** The `service.instance.id` uniquely identifies a resource, however, it’s being misused when another resource attribute is present indicating that two workloads are sharing the same `service.instance.id`.
 
 **Target:** Resource
 
-**Criteria:** The `service.instance.id` resource attribute is present. 
+**Criteria:** The `service.instance.id` resource attribute is not unique across logical resources, e.g., different Kubernetes pods. 
 
 **Severity:** Important (so that it negates the effects of RES-001)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description and criteria for the RES-002 rule to clarify that it now detects duplicate, rather than misused, `service.instance.id` values across logical resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->