### PR TITLE
chore: update slack link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The Instrumentation Score Specification defines a standardized metric for assess
 
 1. **Read the specification**: Review the main [specification.md](./specification.md) document
 2. **Understand the goals**: Familiarize yourself with the project's objectives and scope
-3. **Join the community**: Connect with us on [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C08U9NN1XBR)
+3. **Join the community**: Connect with us on [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C090FEG5R0F)
 4. **Review existing issues**: Check [GitHub Issues](https://github.com/instrumentation-score/spec/issues) for current discussions
 
 ## Ways to Contribute
@@ -140,7 +140,7 @@ feat: add rule for missing `service.version` attribute
 ### Discussion Channels
 
 - **GitHub Issues**: For specific problems, proposals, and bugs
-- **CNCF Slack**: Join [#instrumentation-score](https://cloud-native.slack.com/archives/C08U9NN1XBR) for real-time discussion
+- **CNCF Slack**: Join [#instrumentation-score](https://cloud-native.slack.com/archives/C090FEG5R0F) for real-time discussion
 - **Pull Requests**: For code and documentation review discussions
 
 ### Getting Help
@@ -182,7 +182,7 @@ Contributors are recognized in several ways:
 ## Questions?
 
 If you have questions about contributing, please:
-- Join our [CNCF Slack channel](https://cloud-native.slack.com/archives/C08U9NN1XBR)
+- Join our [CNCF Slack channel](https://cloud-native.slack.com/archives/C090FEG5R0F)
 - Create a GitHub issue with the "question" label
 - Review the [governance document](./GOVERNANCE.md) for project structure
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,7 +64,7 @@ All community members are encouraged to participate through:
 
 ### Public Forums
 - **GitHub Issues**: Technical discussions and bug reports
-- **CNCF Slack**: Join [#instrumentation-score channel](https://cloud-native.slack.com/archives/C08U9NN1XBR) for technical discussions
+- **CNCF Slack**: Join [#instrumentation-score channel](https://cloud-native.slack.com/archives/C090FEG5R0F) for technical discussions
 - **Documentation**: To be maintained in the project repository
 
 ### Regular Activities

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A standardized metric for assessing OpenTelemetry instrumentation quality
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![CNCF Slack](https://img.shields.io/badge/CNCF%20Slack-%23instrumentation--score-blue)](https://cloud-native.slack.com/archives/C08U9NN1XBR)
+[![CNCF Slack](https://img.shields.io/badge/CNCF%20Slack-%23instrumentation--score-blue)](https://cloud-native.slack.com/archives/C090FEG5R0F)
 
 ## Overview
 
@@ -135,7 +135,7 @@ criteria: "Resource attributes must contain 'service.name' key with non-empty va
 
 We welcome contributions from the OpenTelemetry community! Here's how to participate:
 
-- 💬 **Join Discussion**: [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C08U9NN1XBR)
+- 💬 **Join Discussion**: [CNCF Slack #instrumentation-score](https://cloud-native.slack.com/archives/C090FEG5R0F)
 - 🐛 **Report Issues**: [GitHub Issues](https://github.com/instrumentation-score/spec/issues)
 - 🔀 **Submit Changes**: Follow our [contributing guide](./CONTRIBUTING.md)
 - 📅 **Attend Meetings**: Community meetings (schedule in Slack)
@@ -176,4 +176,4 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 **Start improving your instrumentation quality today!** 🚀
 
-For questions, feedback, or discussions, join us in the [CNCF Slack #instrumentation-score channel](https://cloud-native.slack.com/archives/C08U9NN1XBR).
+For questions, feedback, or discussions, join us in the [CNCF Slack #instrumentation-score channel](https://cloud-native.slack.com/archives/C090FEG5R0F).


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CNCF Slack channel URL in the README, CONTRIBUTING, and GOVERNANCE documentation to reflect the new channel address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->