### PR TITLE
add rule proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-rule.yml
+++ b/.github/ISSUE_TEMPLATE/propose-rule.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time submit a rule proposal! Please fill in as many details below
+        Thanks for taking the time to submit a rule proposal! Please fill in as many details as possible.
   - type: textarea
     id: rule-proposal
     attributes:

--- a/.github/ISSUE_TEMPLATE/propose-rule.yml
+++ b/.github/ISSUE_TEMPLATE/propose-rule.yml
@@ -12,16 +12,16 @@ body:
     attributes:
       label: Proposal
       value: |
-        **Rule ID:** 
+        **Rule ID:**
 
-        **Description:** 
+        **Description:**
 
-        **Rationale:** 
+        **Rationale:**
 
-        **Target:** 
+        **Target:**
 
-        **Criteria:** 
+        **Criteria:**
 
-        **Impact:** 
+        **Impact:**
 
-        **Type:** 
+        **Type:**

--- a/.github/ISSUE_TEMPLATE/propose-rule.yml
+++ b/.github/ISSUE_TEMPLATE/propose-rule.yml
@@ -1,0 +1,27 @@
+name: Propose a new rule
+description: Submit a proposal for a new rule.
+title: "Rule proposal: "
+labels: ["rule"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time submit a rule proposal! Please fill in as many details below
+  - type: textarea
+    id: rule-proposal
+    attributes:
+      label: Proposal
+      value: |
+        **Rule ID:** 
+
+        **Description:** 
+
+        **Rationale:** 
+
+        **Target:** 
+
+        **Criteria:** 
+
+        **Impact:** 
+
+        **Type:** 


### PR DESCRIPTION
Since the format of a new rule is so clear, it might be useful to have an issue template that prompts contributors w/ all the fields of the rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new GitHub issue template to streamline submitting proposals for new rules, guiding users to provide key details in a structured format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->