### PR TITLE
Update MET-004 to remove type and make it neutral

### DIFF
--- a/rules/MET-004.md
+++ b/rules/MET-004.md
@@ -1,6 +1,6 @@
 **Rule ID:** MET-004
 
-**Description:** A histogram metric consistently uses the same histogram buckets.
+**Description:** Histogram metrics consistently use the same histogram buckets per metric name.
 
 **Rationale:** Histograms use buckets to count occurrences in given ranges. Inconsistent buckets may make quantile aggregations less precise.
 


### PR DESCRIPTION
Recent changes have made rules conform to a single way of defining criteria, without the need of a negative. This rule got merged still following the old definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the description of rule MET-004 to emphasize consistent use of histogram buckets per metric name.
  * Removed the rule type specification for MET-004.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->