### PR TITLE
Update MET-006.md

### DIFF
--- a/rules/MET-006.md
+++ b/rules/MET-006.md
@@ -2,7 +2,7 @@
 
 **Description:** Metric names do not equal semantic convention attribute keys.
 
-**Rationale:** **Rationale:** A metric name that exactly matches an attribute key defined in the semantic conventions (e.g., `http.response.status_code`, a span-level attribute) causes confusion and should be avoided.
+**Rationale:** A metric name that exactly matches an attribute key defined in the semantic conventions (e.g., `http.response.status_code`, a span-level attribute) causes confusion and should be avoided.
 
 **Target:** Metric
 

--- a/rules/MET-006.md
+++ b/rules/MET-006.md
@@ -1,11 +1,11 @@
 **Rule ID:** MET-006
 
-**Description:** Metric names do not contain a semantic convention attribute.
+**Description:** Metric names do not equal semantic convention attribute keys.
 
-**Rationale:** A metric exists in the context of semantic conventions defined as resource attributes. Duplicating this information in the metric makes it less portable and long, especially if used as a prefix.
+**Rationale:** A metric name equals defined an attribute key defined in the semantic conventions, e.g., having a metric called `http.response.status_code`, which is is also a span-level attribute.
 
 **Target:** Metric
 
-**Criteria**: Metric names do not contain a portion of a semantic convention attribute (example: `amazon.metric.name` when `cloud.provider.id` is set to `amazon`).
+**Criteria**: Metric names do not equal any of the attribute keys specified in semantic conventions.
 
 **Impact:** Important

--- a/rules/MET-006.md
+++ b/rules/MET-006.md
@@ -2,10 +2,10 @@
 
 **Description:** Metric names do not equal semantic convention attribute keys.
 
-**Rationale:** A metric name equals defined an attribute key defined in the semantic conventions, e.g., having a metric called `http.response.status_code`, which is is also a span-level attribute.
+**Rationale:** **Rationale:** A metric name that exactly matches an attribute key defined in the semantic conventions (e.g., `http.response.status_code`, a span-level attribute) causes confusion and should be avoided.
 
 **Target:** Metric
 
-**Criteria**: Metric names do not equal any of the attribute keys specified in semantic conventions.
+**Criteria**: Metric names must not equal any of the attribute keys specified in semantic conventions.
 
 **Impact:** Important


### PR DESCRIPTION
Clarify the rule and reduce its scope of equality, instead of prefix

Closes #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the description, rationale, and criteria for the MET-006 rule to specify that metric names should not exactly match semantic convention attribute keys, with updated examples and explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->