### PR TITLE
fix: standardize score range to consistent 0-100 throughout specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The Instrumentation Score uses these qualitative categories:
 | 90-100      | **Excellent**         | High standard of instrumentation quality   |
 | 75-89       | **Good**              | Solid quality; minor improvements possible |
 | 50-74       | **Needs Improvement** | Tangible issues requiring attention        |
-| 10-49       | **Poor**              | Significant problems needing urgent action |
+| 0-49        | **Poor**              | Significant problems needing urgent action |
 
 ### How It Works
 

--- a/specification.md
+++ b/specification.md
@@ -53,7 +53,7 @@ These examples underscore the need for the Instrumentation Score to be standardi
 The primary **goals** of this specification are to:
 
 * Define a **standardized**, vendor-neutral metric for instrumentation quality.  
-* Provide **quantifiable and transparent** feedback via a numerical score (10-100) and an open calculation method.  
+* Provide **quantifiable and transparent** feedback via a numerical score (0-100) and an open calculation method.  
 * Offer **actionable insights** by structuring the score to guide improvements.  
 * **Promote best practices** in line with OpenTelemetry standards.  
 * Establish a **governed framework** allowing for community-driven evolution.  
@@ -134,7 +134,7 @@ To simplify interpretation, the numerical score is mapped to intuitive qualitati
 | 90 \- 100 | **Excellent** | Represents a high standard of instrumentation quality. |
 | 75 \- 89 | **Good** | Solid, acceptable quality; minor improvements may be possible. |
 | 50 \- 74 | **Needs Improvement** | Indicates tangible issues requiring attention and remediation. |
-| 10 \- 49 | **Poor** | Signals significant instrumentation problems needing urgent action. |
+| 0 \- 49 | **Poor** | Signals significant instrumentation problems needing urgent action. |
 
 These ranges provide clear signals for action, with "Excellent" being a distinct achievement and "Poor" indicating likely critical issues.
 


### PR DESCRIPTION
## Summary
- Fixed inconsistent score range references in specification
- Updated specification goals to use 0-100 range (was 10-100)  
- Updated score range tables to start from 0 (was 10-49 for Poor category)
- Ensures consistent 0-100 range across all documentation

## Changes
- `specification.md:56` - Updated goals section from "(10-100)" to "(0-100)"
- `specification.md:137` - Updated Poor category from "10-49" to "0-49"
- `README.md:66` - Updated Poor category from "10-49" to "0-49"

## Test plan
- [x] Verified all score range references are now consistent
- [x] Confirmed no other 10-100 references remain
- [x] Validated scoring tables cover full 0-100 range

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified overall score scale to 0–100 across guides.
  * Updated “Poor” category to 0–49 (previously 10–49) in score interpretation.
  * Aligned qualitative ranges and guidance for consistency with the new lower bound.
  * Added a goal emphasizing benchmarking of instrumentation quality.
  * Refreshed tables and wording in Quick Start and specification for clarity.
  * No functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->