### PR TITLE
Add RES-006 and RES-007 resource attribute rules

### DIFF
--- a/rules/RES-006.md
+++ b/rules/RES-006.md
@@ -1,0 +1,16 @@
+**Rule ID:** RES-006
+
+**Description:** `service.criticality` uses a valid enum value
+
+**Rationale:** The `service.criticality` resource attribute indicates the operational importance level of a service. Using standardized enum values enables automated prioritization of alerts, incidents, and resource allocation decisions across heterogeneous environments. Without consistent values, tooling cannot reliably compare or act on criticality levels. Defined in the [OTel Service and Deployment Semantic Conventions](https://github.com/open-telemetry/community/blob/main/projects/service-and-deployment-semconv.md) (Phase 1).
+
+**Target:** Resource
+
+**Criteria:** If the `service.criticality` resource attribute is present, its value MUST be one of the following enum values: `mission_critical`, `high`, `medium`, `low`. The attribute MUST NOT contain any other value.
+
+**Examples:**
+
+- "Resource attribute `service.criticality` is set to `critical` instead of a valid enum value (`mission_critical`, `high`, `medium`, `low`)."
+- "Resource attribute `service.criticality` is set to `HIGH` (uppercase) instead of the expected lowercase `high`."
+
+**Impact:** Normal

--- a/rules/RES-007.md
+++ b/rules/RES-007.md
@@ -1,0 +1,16 @@
+**Rule ID:** RES-007
+
+**Description:** `deployment.environment.name` is present
+
+**Rationale:** The `deployment.environment.name` resource attribute specifies the environment where the service is deployed (e.g., `production`, `staging`). This attribute is essential for environment-aware analysis, enabling teams to filter telemetry by environment, apply environment-specific alerting thresholds, and prevent confusion between production and non-production data. It is part of the [OpenTelemetry Resource Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/) and is being stabilized as part of the [OTel Service and Deployment Semantic Conventions](https://github.com/open-telemetry/community/blob/main/projects/service-and-deployment-semconv.md) (Phase 2).
+
+**Target:** Resource
+
+**Criteria:** Resource attributes MUST contain a `deployment.environment.name` key with a non-empty string value. The attribute MUST NOT be null, undefined, or an empty string.
+
+**Examples:**
+
+- "Resource attribute `deployment.environment.name` is missing from the resource attributes."
+- "Resource attribute `deployment.environment.name` is present but has an empty string value."
+
+**Impact:** Important


### PR DESCRIPTION
## Summary

Adds two new instrumentation scoring rules based on [OTel Service and Deployment Semantic Conventions](https://github.com/open-telemetry/community/blob/main/projects/service-and-deployment-semconv.md) (community#2837):

- **RES-006** — `service.criticality` enum validation (`mission_critical`, `high`, `medium`, `low`) — Normal impact
- **RES-007** — `deployment.environment.name` presence check — Important impact

## Future work

Two additional rules are deferred until their semantic conventions are approved:
- `service.owner` (Phase 1 — semconv not yet approved)
- `data.sensitivity` (Phase 3 — not yet defined in semconv)

## Test plan

- [ ] Verify rule files follow the existing template format
- [ ] Confirm attribute names and enum values match OTel community#2837
- [ ] Review impact level assignments

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance requiring `service.criticality`, when provided, to use one of four standardized values: `mission_critical`, `high`, `medium`, or `low`.
  - Added guidance requiring resources to include a non-empty `deployment.environment.name` value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->